### PR TITLE
`/gh user` no longer fails if user is an organization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,7 @@
         "editor.rulers": [88],
     },
     "ruff.organizeImports": true,
-    "ruff.lint.args": [
-        "--extend-ignore=I",
-    ],
+    "ruff.lint.ignore": ["I"],
     "python.languageServer": "Pylance",
     "python.analysis.diagnosticMode": "workspace",
     "python.testing.unittestEnabled": false,


### PR DESCRIPTION
should fix #4. also added some detailed info depending on user type 

![image](https://github.com/user-attachments/assets/b21410ec-1d73-46ba-9544-b3eeb3641639)
